### PR TITLE
Support to SSH format of ghq command.

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	re = regexp.MustCompile(`^(?:git@github\.com:|https://github\.com/)([^/]+)/([^/]+?)(?:\.git)?$`)
+	re = regexp.MustCompile(`^(?:(?:ssh://)?git@github\.com/?|https://github\.com/)([^/]+)/([^/]+?)(?:\.git)?$`)
 )
 
 func main() {


### PR DESCRIPTION
When the git clone in ghq command, remote url is `ssh://git@github.com/owner/repo/`.